### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 Run
 
 ```
+$ docker build -t piwigo-docker ./
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
Update documentation in order to build and locally tag `piwigo-docker`.
Prevent `unknow piwigo-docker; registry login: denied` error 