### PR TITLE
Add php7-exif

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Moritz Heiber <hello@heiber.im>"
 ENV PIWIGO_VERSION="2.10.2" \
   PIWIGO_CHECKSUM="0de75de7da9d9b8058e208cf78d6f20852a790fca6d8231d432f3f62d12939ff"
 
-RUN set -x && apk --no-cache add curl php7 php7-gd php7-mysqli php7-json php7-session && \
+RUN set -x && apk --no-cache add curl php7 php7-gd php7-mysqli php7-json php7-session php7-exif && \
   curl -Lo /tmp/piwigo.zip "http://piwigo.org/download/dlcounter.php?code=${PIWIGO_VERSION}" && \
   echo "${PIWIGO_CHECKSUM}  /tmp/piwigo.zip" | sha256sum -wsc - && \
   adduser -h /piwigo -DS piwigo && \


### PR DESCRIPTION
This adds the PHP module exif, so piwigo can read EXIF information from JPG files.